### PR TITLE
Fix legacy rpc unit test not sharing same default legacy timeout

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -442,7 +442,7 @@ impl Default for RpcServerArgs {
             builder_disallow: Default::default(),
             legacy_rpc_url: None,
             legacy_cutoff_block: None,
-            legacy_rpc_timeout: None,
+            legacy_rpc_timeout: Some("30s".into()),
             rpc_send_raw_transaction_sync_timeout:
                 constants::RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
         }


### PR DESCRIPTION
Before: `cargo t -p reth-node-core` fails

After: `cargo t -p reth-node-core` passes