### PR TITLE
Ignore xlayer-e2e-test meant for local testing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           cargo nextest run \
             --locked --features "asm-keccak ${{ matrix.network }}" \
-            --workspace --exclude ef-tests \
+            --workspace --exclude ef-tests --exclude xlayer-e2e-test \
             -E "kind(test) and not binary(e2e_testsuite)"
       - if: matrix.network == 'optimism'
         name: Run tests


### PR DESCRIPTION
Currently CI is failing as the test creates a HTTP client on a local running service. So we can ignore it for now.

Disclaimer: this will not work as the actual workflow lies somewhere else...