### PR TITLE
feat(RPC): Support eth_minGasPrice rpc method

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -291,6 +291,11 @@ pub trait EthApi<
     #[method(name = "gasPrice")]
     async fn gas_price(&self) -> RpcResult<U256>;
 
+    // For xlayer
+    /// Returns the minimum gas price (base fee + default suggested fee) in wei.
+    #[method(name = "minGasPrice")]
+    async fn min_gas_price(&self) -> RpcResult<U256>;
+
     /// Returns the account details by specifying an address and a block number/tag
     #[method(name = "getAccount")]
     async fn get_account(
@@ -796,6 +801,13 @@ where
     async fn gas_price(&self) -> RpcResult<U256> {
         trace!(target: "rpc::eth", "Serving eth_gasPrice");
         Ok(EthFees::gas_price(self).await?)
+    }
+
+    // For xlayer
+    /// Handler for: `eth_minGasPrice`
+    async fn min_gas_price(&self) -> RpcResult<U256> {
+        trace!(target: "rpc::eth", "Serving eth_minGasPrice");
+        Ok(EthFees::min_gas_price(self).await?)
     }
 
     /// Handler for: `eth_getAccount`


### PR DESCRIPTION
This pull request adds support for a new `eth_minGasPrice` RPC method, which returns the minimum gas price (base fee plus a default suggested fee) in wei. The changes introduce this functionality across the API trait, its implementation, and the fee calculation helpers.
```
minGasPrice = baseFee + default-suggested-fee 
```

**New eth_minGasPrice RPC method support:**

* Added a new async method `min_gas_price` to the `EthApi` trait, exposing the `eth_minGasPrice` RPC endpoint.
* Implemented the handler for the new `min_gas_price` method in the `EthApi` trait, which calls the corresponding fee helper and logs the request.

**Fee calculation enhancements:**

* Added a `min_gas_price` method to the `EthFees` trait, delegating to the underlying fee loader.
* Implemented the `min_gas_price` logic in the fee loader, which fetches the latest block header, extracts the base fee, and adds the default suggested fee from the gas oracle configuration.

**Configuration**
The default-suggested-fee can configure in startup params like this
```
--gpo.default-suggested-fee 1
```